### PR TITLE
Add support for getting data from morph.io scrapers

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,11 @@ Or install it yourself as:
 
 ## Usage
 
+### Replace your local `data.sqlite` with one from another scraper
+
 **WARNING**: This will destroy any existing data in the current scraper's `data.sqlite` database, so make sure that you _actually_ want to do this!
 
-### Basic
+#### Basic
 
 Make sure your morph.io API key is set in the `MORPH_API_KEY` environment variable. Then you can overwrite the current `data.sqlite` by adding the following code to a scraper:
 
@@ -37,7 +39,7 @@ MorphScraper::Database.new('tmtmtmtm/malta-parliament').write(force: true)
 
 **Note**: The above code will overwrite the database of the _current_ scraper with the contents of the _named_ scraper's database **every single time** this code is run. You might want to make this code conditional on an environment variable or remove it once you've used it, otherwise it will overwrite your database on each run and you can potentially loose data.
 
-### Advanced
+#### Advanced
 
 If you require more control over the API key and the path that the database is written to:
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,26 @@ scraper_db = MorphScraper::Database.new('tmtmtmtm/malta-parliament', api_key: 'r
 scraper_db.write(path: 'data.sqlite', force: true)
 ```
 
+### Getting data from another scraper
+
+In some situations you might just want to get a subset of the data from a remote scraper, or you might want to get all of the data and then merge it with the existing data that you have locally, for that you can use the `#data` and `#query` methods:
+
+To get all the data from a table back as an array of hashes, use `Database#data`:
+
+```ruby
+require 'morph_scraper/database'
+scraper_db = MorphScraper::Database.new('tmtmtmtm/malta-parliament')
+
+# Equivalent to SELECT * FROM data;
+scraper_db.data
+
+# Equivalent to SELECT * FROM terms;
+scraper_db.data(:terms)
+
+# Or you can run a custom query
+scraper_db.query('SELECT *, 5 as term FROM data LIMIT 10')
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@ require 'bundler/gem_tasks'
 require 'rake/testtask'
 
 Rake::TestTask.new(:test) do |t|
+  t.warning = false
   t.libs << 'test'
   t.libs << 'lib'
   t.test_files = FileList['test/**/*_test.rb']

--- a/lib/morph_scraper/database.rb
+++ b/lib/morph_scraper/database.rb
@@ -1,5 +1,6 @@
 require 'morph_scraper/database/version'
 require 'open-uri'
+require 'sequel'
 
 module MorphScraper
   # Copy a sqlite database from another morph scraper into the current one.
@@ -20,6 +21,10 @@ module MorphScraper
       IO.copy_stream(scraper_database.path, path)
     end
 
+    def data
+      sequel[:data].to_a
+    end
+
     private
 
     attr_reader :scraper, :api_key
@@ -28,6 +33,10 @@ module MorphScraper
       @scraper_database ||= Tempfile.new.tap do |tmp_file|
         IO.copy_stream(open("https://morph.io/#{scraper}/data.sqlite?key=#{api_key}"), tmp_file.path)
       end
+    end
+
+    def sequel
+      @sequel ||= Sequel.sqlite(scraper_database.path)
     end
   end
 end

--- a/lib/morph_scraper/database.rb
+++ b/lib/morph_scraper/database.rb
@@ -38,7 +38,7 @@ module MorphScraper
     attr_reader :scraper, :api_key
 
     def scraper_database
-      @scraper_database ||= Tempfile.new.tap do |tmp_file|
+      @scraper_database ||= Tempfile.new('morph_scraper-database').tap do |tmp_file|
         IO.copy_stream(open("https://morph.io/#{scraper}/data.sqlite?key=#{api_key}"), tmp_file.path)
       end
     end

--- a/lib/morph_scraper/database.rb
+++ b/lib/morph_scraper/database.rb
@@ -29,6 +29,10 @@ module MorphScraper
       sequel[table_name.to_sym].to_a
     end
 
+    def query(sql)
+      sequel[sql].to_a
+    end
+
     private
 
     attr_reader :scraper, :api_key

--- a/lib/morph_scraper/database.rb
+++ b/lib/morph_scraper/database.rb
@@ -17,7 +17,7 @@ module MorphScraper
           'Pass the `force` option to the constructor to overwrite.'
         raise Error, message
       end
-      File.write(path, scraper_database)
+      IO.copy_stream(scraper_database.path, path)
     end
 
     private
@@ -25,7 +25,9 @@ module MorphScraper
     attr_reader :scraper, :api_key
 
     def scraper_database
-      open("https://morph.io/#{scraper}/data.sqlite?key=#{api_key}").read
+      @scraper_database ||= Tempfile.new.tap do |tmp_file|
+        IO.copy_stream(open("https://morph.io/#{scraper}/data.sqlite?key=#{api_key}"), tmp_file.path)
+      end
     end
   end
 end

--- a/lib/morph_scraper/database.rb
+++ b/lib/morph_scraper/database.rb
@@ -25,6 +25,10 @@ module MorphScraper
       sequel[:data].to_a
     end
 
+    def table(table_name)
+      sequel[table_name.to_sym].to_a
+    end
+
     private
 
     attr_reader :scraper, :api_key

--- a/lib/morph_scraper/database.rb
+++ b/lib/morph_scraper/database.rb
@@ -21,11 +21,7 @@ module MorphScraper
       IO.copy_stream(scraper_database.path, path)
     end
 
-    def data
-      sequel[:data].to_a
-    end
-
-    def table(table_name)
+    def data(table_name = :data)
       sequel[table_name.to_sym].to_a
     end
 

--- a/morph_scraper-database.gemspec
+++ b/morph_scraper-database.gemspec
@@ -20,6 +20,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_runtime_dependency 'sequel', '< 5'
+  spec.add_runtime_dependency 'sqlite3'
+
   spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'minitest', '~> 5.0'

--- a/test/morph_scraper/database_test.rb
+++ b/test/morph_scraper/database_test.rb
@@ -41,13 +41,29 @@ describe MorphScraper::Database do
   end
 
   describe 'getting data out' do
-    before do
-      stub_request(:get, 'https://morph.io/chrismytton/denmark-folketing-wikidata/data.sqlite?key=secret')
-        .to_return(body: create_database(data: [{ test: 'foo' }]).read)
+    let(:database) do
+      create_database(
+        data:  [
+          { test: 'foo' },
+        ],
+        names: [
+          { name: 'Alice' },
+          { name: 'Bob' },
+        ]
+      )
     end
 
-    it 'returns the data' do
+    before do
+      stub_request(:get, 'https://morph.io/chrismytton/denmark-folketing-wikidata/data.sqlite?key=secret')
+        .to_return(body: database.read)
+    end
+
+    it 'returns the data table' do
       subject.data.must_equal [{ test: 'foo' }]
+    end
+
+    it 'returns other tables' do
+      subject.table('names').must_equal [{ name: 'Alice' }, { name: 'Bob' }]
     end
   end
 end

--- a/test/morph_scraper/database_test.rb
+++ b/test/morph_scraper/database_test.rb
@@ -5,12 +5,6 @@ describe MorphScraper::Database do
     ::MorphScraper::Database::VERSION.wont_be_nil
   end
 
-  def with_tmp_dir(&block)
-    Dir.mktmpdir do |tmp_dir|
-      Dir.chdir(tmp_dir, &block)
-    end
-  end
-
   before do
     stub_request(:get, 'https://morph.io/chrismytton/denmark-folketing-wikidata/data.sqlite?key=secret')
       .to_return(body: 'remote data')

--- a/test/morph_scraper/database_test.rb
+++ b/test/morph_scraper/database_test.rb
@@ -39,4 +39,15 @@ describe MorphScraper::Database do
       end
     end
   end
+
+  describe 'getting data out' do
+    before do
+      stub_request(:get, 'https://morph.io/chrismytton/denmark-folketing-wikidata/data.sqlite?key=secret')
+        .to_return(body: create_database(data: [{ test: 'foo' }]).read)
+    end
+
+    it 'returns the data' do
+      subject.data.must_equal [{ test: 'foo' }]
+    end
+  end
 end

--- a/test/morph_scraper/database_test.rb
+++ b/test/morph_scraper/database_test.rb
@@ -63,7 +63,7 @@ describe MorphScraper::Database do
     end
 
     it 'returns other tables' do
-      subject.table('names').must_equal [{ name: 'Alice' }, { name: 'Bob' }]
+      subject.data('names').must_equal [{ name: 'Alice' }, { name: 'Bob' }]
     end
 
     it 'allows arbitraty SQL queries' do

--- a/test/morph_scraper/database_test.rb
+++ b/test/morph_scraper/database_test.rb
@@ -65,5 +65,10 @@ describe MorphScraper::Database do
     it 'returns other tables' do
       subject.table('names').must_equal [{ name: 'Alice' }, { name: 'Bob' }]
     end
+
+    it 'allows arbitraty SQL queries' do
+      expected = [{ name: 'ALICE', term: 5 }, { name: 'BOB', term: 5 }]
+      subject.query('select upper(name) name, 5 as term from names').must_equal expected
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,3 +3,13 @@ require 'morph_scraper/database'
 
 require 'minitest/autorun'
 require 'webmock/minitest'
+
+module Minitest
+  class Spec
+    def with_tmp_dir(&block)
+      Dir.mktmpdir do |tmp_dir|
+        Dir.chdir(tmp_dir, &block)
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,7 +14,7 @@ module Minitest
     end
 
     def create_database(data)
-      Tempfile.new.tap do |tmp_file|
+      Tempfile.new('morph_scraper-database:test_helper').tap do |tmp_file|
         db = Sequel.sqlite(tmp_file.path)
         data.each do |table, rows|
           db.create_table(table) do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@ require 'morph_scraper/database'
 
 require 'minitest/autorun'
 require 'webmock/minitest'
+require 'pry'
 
 module Minitest
   class Spec

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,5 +12,17 @@ module Minitest
         Dir.chdir(tmp_dir, &block)
       end
     end
+
+    def create_database(data)
+      Tempfile.new.tap do |tmp_file|
+        db = Sequel.sqlite(tmp_file.path)
+        data.each do |table, rows|
+          db.create_table(table) do
+            rows.first.keys.each { |key| String key }
+          end
+          rows.each { |row| db[table.to_sym].insert(row) }
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
# What does this do?

This adds ~~3~~ 2 new methods for getting data from a remote morph scraper, `MorphScraper::Database#data`, ~~`MorphScraper::Database#table`~~ and `MorphScraper::Database#query`. All of these methods return an array of hashes representing the records from the remote scraper's database.

``` ruby
db = MorphScraper::Database.new('tmtmtmtm/malta-parliament')

# Equivalent to 'SELECT * FROM data'
db.data

# Equivalent to 'SELECT * FROM terms'
db.data(:terms)

# Or just execute arbitrary queries
db.query('SELECT *, 5 as term FROM data')
```
# Why was this needed?

This gem already [has a method](https://github.com/everypolitician/morph_scraper-database/blob/bcfd6fb77d288d2e59ca5405fea9f561f1ba6db3/lib/morph_scraper/database.rb#L14-L21) for copying the database from another morph scraper into the current scraper's `data.sqlite`, but it completely overwrites what's in the current scrapers database. This is OK if you've just created a new scraper and want the new scraper's database to be identical to the old one, but falls down for anything more complicated than that.

To solve this problem this pull request adds the methods mentioned above to give you full programatic access to the contents of a morph scraper. This can be used by a scraper to import the partial contents of another scraper. It can also potentially be used as part of the everypolitician-data build process to make it easier to work with remote scrapers.
# Implementation notes

This is built on top of [Sequel](https://github.com/jeremyevans/sequel), so most of the heavy lifting is done by that gem, with this gem just shuttling the data around and providing some convenience methods for accessing the data.
