### PR TITLE
Use Morph's JSON API

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,12 @@
 AllCops:
   TargetRubyVersion: 2.1
 
+# Minitest::Spec uses long blocks to contains the specs, so disable this check
+# for the tests.
+Metrics/BlockLength:
+  Exclude:
+    - 'test/**/*'
+
 inherit_from:
   - https://raw.githubusercontent.com/everypolitician/everypolitician-data/master/.rubocop_base.yml
   - .rubocop_todo.yml

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ require 'morph_scraper/database'
 MorphScraper::Database.new('tmtmtmtm/malta-parliament').write(force: true)
 ```
 
-**Note**: The above code will overwrite the database of the _current_ scraper with the contents of the _named_ scraper's database **every single time** this code is run. You might want to make this code conditional on an environment variable or remove it once you've used it, otherwise it will overwrite your database on each run and you can potentially loose data.
+**Note**: The above code will overwrite the database of the _current_ scraper with the contents of the _named_ scraper's database **every single time** this code is run. You might want to make this code conditional on an environment variable or remove it once you've used it, otherwise it will overwrite your database on each run and you can potentially lose data.
 
 #### Advanced
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,11 @@ Or install it yourself as:
 
 ## Usage
 
+### Replace your local `data.sqlite` with one from another scraper
+
 **WARNING**: This will destroy any existing data in the current scraper's `data.sqlite` database, so make sure that you _actually_ want to do this!
 
-### Basic
+#### Basic
 
 Make sure your morph.io API key is set in the `MORPH_API_KEY` environment variable. Then you can overwrite the current `data.sqlite` by adding the following code to a scraper:
 
@@ -37,7 +39,7 @@ MorphScraper::Database.new('tmtmtmtm/malta-parliament').write(force: true)
 
 **Note**: The above code will overwrite the database of the _current_ scraper with the contents of the _named_ scraper's database **every single time** this code is run. You might want to make this code conditional on an environment variable or remove it once you've used it, otherwise it will overwrite your database on each run and you can potentially loose data.
 
-### Advanced
+#### Advanced
 
 If you require more control over the API key and the path that the database is written to:
 

--- a/README.md
+++ b/README.md
@@ -77,10 +77,8 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/morph_scraper-database.
-
+Bug reports and pull requests are welcome on GitHub at https://github.com/everypolitician/morph_scraper-database.
 
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/README.md
+++ b/README.md
@@ -49,6 +49,26 @@ scraper_db = MorphScraper::Database.new('tmtmtmtm/malta-parliament', api_key: 'r
 scraper_db.write(path: 'data.sqlite', force: true)
 ```
 
+### Getting data from another scraper
+
+In some situations you might just want to get a subset of the data from a remote scraper, or you might want to get all of the data and then merge it with the existing data that you have locally, for that you can use the `#data` and `#query` methods:
+
+To get all the data from a table back as an array of hashes, use `Database#data`:
+
+```ruby
+require 'morph_scraper/database'
+scraper_db = MorphScraper::Database.new('tmtmtmtm/malta-parliament')
+
+# Equivalent to SELECT * FROM data;
+scraper_db.data
+
+# Equivalent to SELECT * FROM terms;
+scraper_db.data(:terms)
+
+# Or you can run a custom query
+scraper_db.query('SELECT *, 5 as term FROM data LIMIT 10')
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/morph_scraper/database.rb
+++ b/lib/morph_scraper/database.rb
@@ -20,6 +20,13 @@ module MorphScraper
       File.write(path, scraper_database)
     end
 
+    def data
+      query = 'SELECT * FROM data'
+      uri = "https://api.morph.io/#{scraper}/data.json" \
+        "?#{URI.encode_www_form(key: api_key, query: query)}"
+      JSON.parse(open(uri).read, symbolize_names: true)
+    end
+
     private
 
     attr_reader :scraper, :api_key

--- a/lib/morph_scraper/database.rb
+++ b/lib/morph_scraper/database.rb
@@ -20,8 +20,8 @@ module MorphScraper
       File.write(path, scraper_database)
     end
 
-    def data
-      query = 'SELECT * FROM data'
+    def data(table = :data)
+      query = "SELECT * FROM #{table}"
       uri = "https://api.morph.io/#{scraper}/data.json" \
         "?#{URI.encode_www_form(key: api_key, query: query)}"
       JSON.parse(open(uri).read, symbolize_names: true)

--- a/lib/morph_scraper/database.rb
+++ b/lib/morph_scraper/database.rb
@@ -1,5 +1,6 @@
 require 'morph_scraper/database/version'
 require 'open-uri'
+require 'json'
 
 module MorphScraper
   # Copy a sqlite database from another morph scraper into the current one.
@@ -21,10 +22,11 @@ module MorphScraper
     end
 
     def data(table = :data)
-      query = "SELECT * FROM #{table}"
-      uri = "https://api.morph.io/#{scraper}/data.json" \
-        "?#{URI.encode_www_form(key: api_key, query: query)}"
-      JSON.parse(open(uri).read, symbolize_names: true)
+      query("SELECT * FROM #{table}")
+    end
+
+    def query(sql)
+      JSON.parse(morph_api_json(sql), symbolize_names: true)
     end
 
     private
@@ -33,6 +35,11 @@ module MorphScraper
 
     def scraper_database
       open("https://morph.io/#{scraper}/data.sqlite?key=#{api_key}").read
+    end
+
+    def morph_api_json(sql)
+      open("https://api.morph.io/#{scraper}/data.json" \
+           "?#{URI.encode_www_form(key: api_key, query: sql)}").read
     end
   end
 end

--- a/test/morph_scraper/database_test.rb
+++ b/test/morph_scraper/database_test.rb
@@ -5,12 +5,6 @@ describe MorphScraper::Database do
     ::MorphScraper::Database::VERSION.wont_be_nil
   end
 
-  def with_tmp_dir(&block)
-    Dir.mktmpdir do |tmp_dir|
-      Dir.chdir(tmp_dir, &block)
-    end
-  end
-
   before do
     stub_request(:get, 'https://morph.io/chrismytton/denmark-folketing-wikidata/data.sqlite?key=secret')
       .to_return(body: 'remote data')

--- a/test/morph_scraper/database_test.rb
+++ b/test/morph_scraper/database_test.rb
@@ -42,17 +42,34 @@ describe MorphScraper::Database do
 
   describe '#data' do
     let(:scraper_slug) { 'everypolitician-scrapers/test-example' }
-    let(:api_response) { [{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }] }
     subject { MorphScraper::Database.new(scraper_slug, api_key: 'secret') }
 
-    before do
-      @morph_api_query = stub_morph_query(scraper_slug, 'SELECT * FROM data')
-                         .to_return(body: api_response.to_json)
+    describe 'with no arguments' do
+      let(:api_response) { [{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }] }
+
+      before do
+        @morph_api_query = stub_morph_query(scraper_slug, 'SELECT * FROM data')
+                           .to_return(body: api_response.to_json)
+      end
+
+      it 'returns the contents of the data table' do
+        subject.data.must_equal api_response
+        assert_requested @morph_api_query
+      end
     end
 
-    it 'returns the contents of the data table with no arguments' do
-      subject.data.must_equal api_response
-      assert_requested @morph_api_query
+    describe 'with a table argument' do
+      let(:api_response) { [{ color: 'Red' }, { color: 'Black' }] }
+
+      before do
+        @morph_api_query = stub_morph_query(scraper_slug, 'SELECT * FROM colors')
+                           .to_return(body: api_response.to_json)
+      end
+
+      it 'returns the contents of the table specified' do
+        subject.data(:colors).must_equal api_response
+        assert_requested @morph_api_query
+      end
     end
   end
 end

--- a/test/morph_scraper/database_test.rb
+++ b/test/morph_scraper/database_test.rb
@@ -39,4 +39,20 @@ describe MorphScraper::Database do
       end
     end
   end
+
+  describe '#data' do
+    let(:scraper_slug) { 'everypolitician-scrapers/test-example' }
+    let(:api_response) { [{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }] }
+    subject { MorphScraper::Database.new(scraper_slug, api_key: 'secret') }
+
+    before do
+      @morph_api_query = stub_morph_query(scraper_slug, 'SELECT * FROM data')
+                         .to_return(body: api_response.to_json)
+    end
+
+    it 'returns the contents of the data table with no arguments' do
+      subject.data.must_equal api_response
+      assert_requested @morph_api_query
+    end
+  end
 end

--- a/test/morph_scraper/database_test.rb
+++ b/test/morph_scraper/database_test.rb
@@ -72,4 +72,20 @@ describe MorphScraper::Database do
       end
     end
   end
+
+  describe '#query' do
+    let(:scraper_slug) { 'everypolitician-scrapers/test-example' }
+    subject { MorphScraper::Database.new(scraper_slug, api_key: 'secret') }
+    let(:api_response) { [{ name: 'ALICE', term: 5 }, { name: 'BOB', term: 5 }] }
+
+    before do
+      @morph_api_query = stub_morph_query(scraper_slug, 'SELECT UPPER(name) name, 5 AS term FROM names')
+                         .to_return(body: api_response.to_json)
+    end
+
+    it 'returns the data for the query' do
+      subject.query('SELECT UPPER(name) name, 5 AS term FROM names').must_equal api_response
+      assert_requested @morph_api_query
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,5 +11,9 @@ module Minitest
         Dir.chdir(tmp_dir, &block)
       end
     end
+
+    def stub_morph_query(scraper, query, key = 'secret')
+      stub_request(:get, "https://api.morph.io/#{scraper}/data.json?#{URI.encode_www_form(key: key, query: query)}")
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,3 +3,13 @@ require 'morph_scraper/database'
 
 require 'minitest/autorun'
 require 'webmock/minitest'
+
+module Minitest
+  class Spec
+    def with_tmp_dir(&block)
+      Dir.mktmpdir do |tmp_dir|
+        Dir.chdir(tmp_dir, &block)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# What does this do?

This adds 2 new methods for getting data from a remote morph scraper, `MorphScraper::Database#data` and `MorphScraper::Database#query`. All of these methods return an array of hashes representing the records from the remote scraper's database.

``` ruby
db = MorphScraper::Database.new('tmtmtmtm/malta-parliament')

# Equivalent to 'SELECT * FROM data'
db.data

# Equivalent to 'SELECT * FROM terms'
db.data(:terms)

# Or just execute arbitrary queries
db.query('SELECT *, 5 as term FROM data')
```
# Why was this needed?

This gem already [has a method](https://github.com/everypolitician/morph_scraper-database/blob/bcfd6fb77d288d2e59ca5405fea9f561f1ba6db3/lib/morph_scraper/database.rb#L14-L21) for copying the database from another morph scraper into the current scraper's `data.sqlite`, but it completely overwrites what's in the current scrapers database. This is OK if you've just created a new scraper and want the new scraper's database to be identical to the old one, but falls down for anything more complicated than that.

To solve this problem this pull request adds the methods mentioned above to give you full programatic access to the contents of a morph scraper. This can be used by a scraper to import the partial contents of another scraper. It can also potentially be used as part of the everypolitician-data build process to make it easier to work with remote scrapers.
# Implementation notes

This is built on top of the [morph.io JSON API](https://morph.io/documentation/api), so most of the heavy lifting is done by them, with this gem just shuttling the data around and providing some convenience methods for accessing the data.
# Related issues

https://github.com/everypolitician/morph_scraper-database/pull/1 was my first attempt at this, but that adds extra dependencies and requires the user to have sqlite installed. With this version we just use http, so the requirements for consumers are kept to a minimum.
